### PR TITLE
fixed bug that let you go to login twice even if you have a token

### DIFF
--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -7,6 +7,7 @@ import {login} from "../../state/actions/auth";
 import * as styles from "./Login.module.css";
 import backgroundStyles from "../../components/formStyleComponent/FormStyleComponent.module.css";
 import FormHeader from "../../components/formStyleComponent/FormHeader";
+import {axiosWithAuth} from "../../utils/axios";
 
 export const Login = props => {
   const [formValues, setFormValues] = useState({
@@ -47,8 +48,21 @@ export const Login = props => {
     getFieldError,
   } = props.form;
   useEffect(() => {
+    async function checkIfTokenValid() {
+      if (localStorage.getItem("token")) {
+        try {
+          const response = await axiosWithAuth().post("/auth/validate_token");
+          if (response.status === 201) {
+            props.history.push("/");
+          }
+        } catch (error) {
+          console.log("Token invalid or expired, please login again!");
+        }
+      }
+    }
+    checkIfTokenValid();
     validateFields();
-  }, [validateFields]);
+  }, [props.history, validateFields]);
   const emailError = isFieldTouched("email") && getFieldError("email");
   const passwordError = isFieldTouched("password") && getFieldError("password");
   return (


### PR DESCRIPTION
# Description

Login will now hit endpoint in useEffect that validates a token if it already exists.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

Remove any items which are not applicable.

- [X] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works .
- [X] New and existing unit tests pass locally with my changes

https://trello.com/c/L6o4aDG3/61-you-can-login-twice-you-shouldnt-be-able-to-access-the-login-page-once-you-are-logged-in